### PR TITLE
read correct bytes to obtain ipv4 client address

### DIFF
--- a/cidr/parse.go
+++ b/cidr/parse.go
@@ -8,3 +8,24 @@ func Parse(s string) *net.IPNet {
 	_, c, _ := net.ParseCIDR(s)
 	return c
 }
+
+func IsIPV4(ip net.IP) (net.IP, bool) {
+	if len(ip) == net.IPv4len {
+		return ip, true
+	}
+
+	if len(ip) == net.IPv6len && IsZeros(ip[0:10]) && ip[10] == 0xff && ip[11] == 0xff {
+		return ip[12:16], true
+	}
+
+	return ip, false
+}
+
+func IsZeros(p net.IP) bool {
+	for i := 0; i < len(p); i++ {
+		if p[i] != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/cidr/tree6.go
+++ b/cidr/tree6.go
@@ -23,7 +23,7 @@ func NewTree6() *Tree6 {
 func (tree *Tree6) AddCIDR(cidr *net.IPNet, val interface{}) {
 	var node, next *Node
 
-	cidrIP, ipv4 := isIPV4(cidr.IP)
+	cidrIP, ipv4 := IsIPV4(cidr.IP)
 	if ipv4 {
 		node = tree.root4
 		next = tree.root4
@@ -78,7 +78,7 @@ func (tree *Tree6) AddCIDR(cidr *net.IPNet, val interface{}) {
 func (tree *Tree6) MostSpecificContains(ip net.IP) (value interface{}) {
 	var node *Node
 
-	wholeIP, ipv4 := isIPV4(ip)
+	wholeIP, ipv4 := IsIPV4(ip)
 	if ipv4 {
 		node = tree.root4
 	} else {
@@ -163,7 +163,7 @@ func (tree *Tree6) MostSpecificContainsIpV6(hi, lo uint64) (value interface{}) {
 	return value
 }
 
-func isIPV4(ip net.IP) (net.IP, bool) {
+func IsIPV4(ip net.IP) (net.IP, bool) {
 	if len(ip) == net.IPv4len {
 		return ip, true
 	}

--- a/cidr/tree6.go
+++ b/cidr/tree6.go
@@ -162,24 +162,3 @@ func (tree *Tree6) MostSpecificContainsIpV6(hi, lo uint64) (value interface{}) {
 
 	return value
 }
-
-func IsIPV4(ip net.IP) (net.IP, bool) {
-	if len(ip) == net.IPv4len {
-		return ip, true
-	}
-
-	if len(ip) == net.IPv6len && isZeros(ip[0:10]) && ip[10] == 0xff && ip[11] == 0xff {
-		return ip[12:16], true
-	}
-
-	return ip, false
-}
-
-func isZeros(p net.IP) bool {
-	for i := 0; i < len(p); i++ {
-		if p[i] != 0 {
-			return false
-		}
-	}
-	return true
-}

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -6,7 +6,6 @@ package udp
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/go-kit/kit/metrics"
 	"net"
 	"syscall"
 	"unsafe"
@@ -160,7 +159,12 @@ func (u *Conn) ListenOut(r EncReader, lhf LightHouseHandlerFunc, cache *firewall
 
 		//metric.Update(int64(n))
 		for i := 0; i < n; i++ {
-			udpAddr.IP = names[i][8:24]
+			if cidr.IsZeros(names[i][8:24]) {
+				udpAddr.IP = names[i][4:8]
+			} else {
+				udpAddr.IP = names[i][8:24]
+			}
+
 			udpAddr.Port = binary.BigEndian.Uint16(names[i][2:4])
 			r(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], h, fwPacket, lhf, nb, q, cache.Get(u.l))
 		}

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -6,12 +6,14 @@ package udp
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/go-kit/kit/metrics"
 	"net"
 	"syscall"
 	"unsafe"
 
 	"github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
+	"github.com/slackhq/nebula/cidr"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/firewall"
 	"github.com/slackhq/nebula/header"
@@ -48,7 +50,7 @@ type _SK_MEMINFO [_SK_MEMINFO_VARS]uint32
 
 func NewListener(l *logrus.Logger, ip string, port int, multi bool, batch int) (*Conn, error) {
 	lip := net.ParseIP(ip)
-	lipV4, isV4 := isIPV4(lip)
+	lipV4, isV4 := cidr.IsIPV4(lip)
 
 	af := unix.AF_INET6
 	if isV4 {
@@ -210,7 +212,7 @@ func (u *Conn) WriteTo(b []byte, addr *Addr) error {
 	var rsaPtr unsafe.Pointer
 	var rsaSize int
 	if u.isV4 {
-		addrV4, isAddrV4 := isIPV4(addr.IP)
+		addrV4, isAddrV4 := cidr.IsIPV4(addr.IP)
 		if !isAddrV4 {
 			u.l.Warnf("socket is IPv4-only, not sending to IPv6 address: %s", addr.IP)
 			return nil


### PR DESCRIPTION
If the bytes that make up the clients' ipv6 address are parsed as all zeroes then assume it's an ipv4-only scenario in which case the client address must be read from other byte indices. 

Also removes the go-kit/kit/metrics import which seems unused and conflicts with the other metrics import at buildtime.